### PR TITLE
Use MockK for accelerator

### DIFF
--- a/aws-globalaccelerator-accelerator/src/test/kotlin/software/amazon/globalaccelerator/accelerator/CreateHandlerTest.kt
+++ b/aws-globalaccelerator-accelerator/src/test/kotlin/software/amazon/globalaccelerator/accelerator/CreateHandlerTest.kt
@@ -1,13 +1,13 @@
 package software.amazon.globalaccelerator.accelerator
 
-import com.amazonaws.AmazonWebServiceResult
-import com.amazonaws.ResponseMetadata
 import com.amazonaws.services.globalaccelerator.model.Accelerator
 import com.amazonaws.services.globalaccelerator.model.AcceleratorStatus
-import com.amazonaws.services.globalaccelerator.model.CreateAcceleratorRequest
 import com.amazonaws.services.globalaccelerator.model.CreateAcceleratorResult
-import com.amazonaws.services.globalaccelerator.model.DescribeAcceleratorRequest
 import com.amazonaws.services.globalaccelerator.model.DescribeAcceleratorResult
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -15,30 +15,22 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertThrows
-import org.mockito.ArgumentMatchers
-import org.mockito.Mock
-import org.mockito.Mockito
-import org.mockito.junit.jupiter.MockitoExtension
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy
 import software.amazon.cloudformation.proxy.Logger
 import software.amazon.cloudformation.proxy.OperationStatus
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest
 import java.util.*
-import java.util.function.Function
 
-@ExtendWith(MockitoExtension::class)
+@ExtendWith(MockKExtension::class)
 class CreateHandlerTest {
-    @Mock
-    private var proxy: AmazonWebServicesClientProxy? = null
+    @MockK
+    lateinit var proxy: AmazonWebServicesClientProxy
 
-    @Mock
-    private var logger: Logger? = null
+    @MockK(relaxed = true)
+    lateinit var logger: Logger
 
     @BeforeEach
-    fun setup() {
-        proxy = Mockito.mock(AmazonWebServicesClientProxy::class.java)
-        logger = Mockito.mock(Logger::class.java)
-    }
+    fun setup() = MockKAnnotations.init(this)
 
     @Test
     fun handleRequest_InitialStateCreatesAccelerator() {
@@ -47,15 +39,14 @@ class CreateHandlerTest {
                         .withStatus(AcceleratorStatus.IN_PROGRESS)
                         .withEnabled(true)
                         .withAcceleratorArn("ACCELERATOR_ARN"))
-        Mockito.doReturn(result).`when`(proxy!!).injectCredentialsAndInvoke(ArgumentMatchers.any(CreateAcceleratorRequest::class.java), ArgumentMatchers.any<Function<CreateAcceleratorRequest, AmazonWebServiceResult<ResponseMetadata>>>())
+        every { proxy.injectCredentialsAndInvoke(ofType(), ofType<ProxyCreateAccelerator>()) } returns result
 
         // create the input
         val handler = CreateHandler()
-        val tags = ArrayList<Tag>()
-        tags.add(Tag.builder().key("K1").value("V1").build())
+        val tags = listOf(Tag.builder().key("K1").value("V1").build())
         val model = ResourceModel.builder().enabled(true).name("AcceleratorTest").tags(tags).build()
         val request = ResourceHandlerRequest.builder<ResourceModel>().desiredResourceState(model).build()
-        val response = handler.handleRequest(proxy!!, request, null, logger!!)
+        val response = handler.handleRequest(proxy, request, null, logger)
         assertNotNull(response)
         assertEquals(OperationStatus.IN_PROGRESS, response.status)
         assertEquals(0, response.callbackDelaySeconds)
@@ -73,12 +64,11 @@ class CreateHandlerTest {
                         .withStatus(AcceleratorStatus.IN_PROGRESS)
                         .withEnabled(true)
                         .withAcceleratorArn("ACCELERATOR_ARN"))
-        Mockito.doReturn(result).`when`(proxy!!).injectCredentialsAndInvoke(ArgumentMatchers.any(DescribeAcceleratorRequest::class.java), ArgumentMatchers.any<Function<DescribeAcceleratorRequest, AmazonWebServiceResult<ResponseMetadata>>>())
+        every { proxy.injectCredentialsAndInvoke(ofType(), ofType<ProxyDescribeAccelerator>()) } returns result
 
         // create the input
         val handler = CreateHandler()
-        val tags = ArrayList<Tag>()
-        tags.add(Tag.builder().key("K1").value("V1").build())
+        val tags = listOf(Tag.builder().key("K1").value("V1").build())
         val model = ResourceModel.builder()
                 .enabled(true)
                 .name("AcceleratorTest")
@@ -86,7 +76,7 @@ class CreateHandlerTest {
                 .acceleratorArn("ACCELERATOR_ARN").build()
         val request = ResourceHandlerRequest.builder<ResourceModel>().desiredResourceState(model).build()
         val callbackContext = CallbackContext(10)
-        val response = handler.handleRequest(proxy!!, request, callbackContext, logger!!)
+        val response = handler.handleRequest(proxy, request, callbackContext, logger)
         assertNotNull(response)
         assertEquals(OperationStatus.IN_PROGRESS, response.status)
         assertEquals(1, response.callbackDelaySeconds)
@@ -105,12 +95,11 @@ class CreateHandlerTest {
                         .withStatus(AcceleratorStatus.DEPLOYED)
                         .withEnabled(true)
                         .withAcceleratorArn("ACCELERATOR_ARN"))
-        Mockito.doReturn(result).`when`(proxy!!).injectCredentialsAndInvoke(ArgumentMatchers.any(DescribeAcceleratorRequest::class.java), ArgumentMatchers.any<Function<DescribeAcceleratorRequest, AmazonWebServiceResult<ResponseMetadata>>>())
+        every { proxy.injectCredentialsAndInvoke(ofType(), ofType<ProxyDescribeAccelerator>()) } returns result
 
         // create the input
         val handler = CreateHandler()
-        val tags = ArrayList<Tag>()
-        tags.add(Tag.builder().key("K1").value("V1").build())
+        val tags = listOf(Tag.builder().key("K1").value("V1").build())
         val model = ResourceModel.builder()
                 .enabled(true)
                 .name("AcceleratorTest")
@@ -118,7 +107,7 @@ class CreateHandlerTest {
                 .acceleratorArn("ACCELERATOR_ARN").build()
         val request = ResourceHandlerRequest.builder<ResourceModel>().desiredResourceState(model).build()
         val callbackContext = CallbackContext(10)
-        val response = handler.handleRequest(proxy!!, request, callbackContext, logger!!)
+        val response = handler.handleRequest(proxy, request, callbackContext, logger)
         assertNotNull(response)
         assertEquals(OperationStatus.SUCCESS, response.status)
         assertEquals(0, response.callbackDelaySeconds)
@@ -137,7 +126,7 @@ class CreateHandlerTest {
         val request = ResourceHandlerRequest.builder<ResourceModel>().desiredResourceState(model).build()
         val callbackContext = CallbackContext(0)
         val exception = assertThrows(RuntimeException::class.java) {
-            handler.handleRequest(proxy!!, request, callbackContext, logger!!)
+            handler.handleRequest(proxy, request, callbackContext, logger)
         }
         assertEquals("Timed out waiting for global accelerator to be deployed.", exception.message)
     }

--- a/aws-globalaccelerator-accelerator/src/test/kotlin/software/amazon/globalaccelerator/accelerator/ReadHandlerTest.kt
+++ b/aws-globalaccelerator-accelerator/src/test/kotlin/software/amazon/globalaccelerator/accelerator/ReadHandlerTest.kt
@@ -1,15 +1,14 @@
 package software.amazon.globalaccelerator.accelerator
 
-import com.amazonaws.AmazonWebServiceResult
-import com.amazonaws.ResponseMetadata
 import com.amazonaws.services.globalaccelerator.model.Accelerator
 import com.amazonaws.services.globalaccelerator.model.AcceleratorNotFoundException
 import com.amazonaws.services.globalaccelerator.model.AcceleratorStatus
-import com.amazonaws.services.globalaccelerator.model.CreateAcceleratorRequest
-import com.amazonaws.services.globalaccelerator.model.DescribeAcceleratorRequest
 import com.amazonaws.services.globalaccelerator.model.DescribeAcceleratorResult
 import com.amazonaws.services.globalaccelerator.model.IpSet
-import org.assertj.core.api.Assertions
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -17,33 +16,27 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.ArgumentMatchers
-import org.mockito.Mock
-import org.mockito.Mockito
-import org.mockito.Mockito.doThrow
-import org.mockito.junit.jupiter.MockitoExtension
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy
 import software.amazon.cloudformation.proxy.HandlerErrorCode
 import software.amazon.cloudformation.proxy.Logger
 import software.amazon.cloudformation.proxy.OperationStatus
-import software.amazon.cloudformation.proxy.ProgressEvent
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest
-import java.util.*
-import java.util.function.Function
 
-@ExtendWith(MockitoExtension::class)
+@ExtendWith(MockKExtension::class)
 class ReadHandlerTest {
-    @Mock
-    private var proxy: AmazonWebServicesClientProxy? = null
+    @MockK
+    lateinit var proxy: AmazonWebServicesClientProxy
 
-    @Mock
-    private var logger: Logger? = null
+    @MockK(relaxed = true)
+    lateinit var logger: Logger
+
+    @BeforeEach
+    fun setup() = MockKAnnotations.init(this)
+
     private val ACCELERATOR_ARN = "arn:aws:globalaccelerator::444607872184:accelerator/88127aa5-01d8-484c-80a0-349daaefce1d"
     private var ipSet: IpSet? = null
     private fun createTestResourceModel(): ResourceModel {
-        val ipAddresses = mutableListOf<String>()
-        ipAddresses.add("10.10.10.1")
-        ipAddresses.add("10.10.10.2")
+        val ipAddresses = listOf("10.10.10.1", "10.10.10.2")
         ipSet = IpSet().withIpAddresses(ipAddresses)
         return ResourceModel.builder()
                 .acceleratorArn(ACCELERATOR_ARN)
@@ -52,12 +45,6 @@ class ReadHandlerTest {
                 .ipAddresses(ipAddresses)
                 .ipAddressType("IPV4")
                 .build()
-    }
-
-    @BeforeEach
-    fun setup() {
-        proxy = Mockito.mock(AmazonWebServicesClientProxy::class.java)
-        logger = Mockito.mock(Logger::class.java)
     }
 
     @Test
@@ -72,10 +59,10 @@ class ReadHandlerTest {
                         .withName("Name")
                         .withIpSets(ipSet)
                 )
-        Mockito.doReturn(describeAcceleratorResult).`when`(proxy)!!.injectCredentialsAndInvoke(ArgumentMatchers.any(DescribeAcceleratorRequest::class.java),
-                ArgumentMatchers.any<Function<DescribeAcceleratorRequest, AmazonWebServiceResult<ResponseMetadata>>>())
+        every { proxy.injectCredentialsAndInvoke(ofType(), ofType<ProxyDescribeAccelerator>()) } returns describeAcceleratorResult
+
         val request = ResourceHandlerRequest.builder<ResourceModel>().desiredResourceState(model).build()
-        val response = ReadHandler().handleRequest(proxy!!, request, null, logger!!)
+        val response = ReadHandler().handleRequest(proxy, request, null, logger)
         assertNotNull(response)
         assertEquals(OperationStatus.SUCCESS, response.status)
         assertNull(response.callbackContext)
@@ -92,10 +79,10 @@ class ReadHandlerTest {
     @Test
     fun handleRequest_nonExistingAccelerator() {
         val model = createTestResourceModel()
-        doThrow(AcceleratorNotFoundException("NOT FOUND")).`when`(proxy)!!.injectCredentialsAndInvoke(ArgumentMatchers.any(DescribeAcceleratorRequest::class.java),
-                ArgumentMatchers.any<Function<DescribeAcceleratorRequest, AmazonWebServiceResult<ResponseMetadata>>>())
+        every { proxy.injectCredentialsAndInvoke(ofType(), ofType<ProxyDescribeAccelerator>()) } throws AcceleratorNotFoundException("NOT FOUND")
+
         val request = ResourceHandlerRequest.builder<ResourceModel>().desiredResourceState(model).build()
-        val response = ReadHandler().handleRequest(proxy!!, request, null, logger!!)
+        val response = ReadHandler().handleRequest(proxy, request, null, logger)
         assertNotNull(response)
         assertEquals(OperationStatus.FAILED, response.status)
         assertEquals(HandlerErrorCode.NotFound, response.errorCode)

--- a/aws-globalaccelerator-accelerator/src/test/kotlin/software/amazon/globalaccelerator/accelerator/TypeAliases.kt
+++ b/aws-globalaccelerator-accelerator/src/test/kotlin/software/amazon/globalaccelerator/accelerator/TypeAliases.kt
@@ -1,0 +1,16 @@
+package software.amazon.globalaccelerator.accelerator
+
+import com.amazonaws.services.globalaccelerator.model.CreateAcceleratorRequest
+import com.amazonaws.services.globalaccelerator.model.CreateAcceleratorResult
+import com.amazonaws.services.globalaccelerator.model.DeleteAcceleratorRequest
+import com.amazonaws.services.globalaccelerator.model.DeleteAcceleratorResult
+import com.amazonaws.services.globalaccelerator.model.DescribeAcceleratorRequest
+import com.amazonaws.services.globalaccelerator.model.DescribeAcceleratorResult
+import com.amazonaws.services.globalaccelerator.model.UpdateAcceleratorRequest
+import com.amazonaws.services.globalaccelerator.model.UpdateAcceleratorResult
+import java.util.function.Function
+
+typealias ProxyDescribeAccelerator = Function<DescribeAcceleratorRequest, DescribeAcceleratorResult>
+typealias ProxyUpdateAccelerator = Function<UpdateAcceleratorRequest, UpdateAcceleratorResult>
+typealias ProxyCreateAccelerator = Function<CreateAcceleratorRequest, CreateAcceleratorResult>
+typealias ProxyDeleteAccelerator = Function<DeleteAcceleratorRequest, DeleteAcceleratorResult>

--- a/aws-globalaccelerator-accelerator/src/test/kotlin/software/amazon/globalaccelerator/accelerator/UpdateHandlerTest.kt
+++ b/aws-globalaccelerator-accelerator/src/test/kotlin/software/amazon/globalaccelerator/accelerator/UpdateHandlerTest.kt
@@ -29,8 +29,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest
 import java.util.function.Function
 
-typealias ProxyDescribeAccelerator = Function<DescribeAcceleratorRequest, DescribeAcceleratorResult>
-typealias ProxyUpdateAccelerator = Function<UpdateAcceleratorRequest, UpdateAcceleratorResult>
+
 
 
 @ExtendWith(MockKExtension::class)


### PR DESCRIPTION
This PR updates all accelerator test cases to use `MockK` insted of direct `Mockito`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
