### PR TITLE
endpoint group region is now writeOnlyProperty

### DIFF
--- a/aws-globalaccelerator-endpointgroup/aws-globalaccelerator-endpointgroup.json
+++ b/aws-globalaccelerator-endpointgroup/aws-globalaccelerator-endpointgroup.json
@@ -94,6 +94,9 @@
     "ListenerArn",
     "EndpointGroupRegion"
   ],
+  "createOnlyProperties": [
+    "/properties/EndpointGroupRegion"
+  ],
   "readOnlyProperties": [
     "/properties/EndpointGroupArn"
   ],

--- a/aws-globalaccelerator-endpointgroup/src/main/kotlin/software/amazon/globalaccelerator/endpointgroup/UpdateHandler.kt
+++ b/aws-globalaccelerator-endpointgroup/src/main/kotlin/software/amazon/globalaccelerator/endpointgroup/UpdateHandler.kt
@@ -52,6 +52,9 @@ class UpdateHandler : BaseHandler<CallbackContext>() {
         val convertedEndpointConfigurations = model.endpointConfigurations?.map {EndpointConfiguration()
                     .withEndpointId(it.endpointId).withWeight(it.weight)}
 
+        // need to fallback if null
+        val trafficDialPercentage = model?.trafficDialPercentage?.toFloat() ?: 100.0f
+
         val request = UpdateEndpointGroupRequest()
                 .withEndpointGroupArn(model.endpointGroupArn)
                 .withHealthCheckPort(model.healthCheckPort)


### PR DESCRIPTION
Endpoint Group Region can not be updated through our user interface today, but we were allowing customers to change this value.  When they changed it, we would have no side-effect although we would succeed the update.  This has been resolved so that if a customer changes this value it attempts to create an entirely new resource.  The use cases for this are limited as the endpoints inside the endpoint group will not be present in the region.  Also, a fix to UpdateEndpointGroup was made to no longer NPE if TrafficDialPercentage was null.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
