### PR TITLE
Adding sample JSON/YAML cloud formation template

### DIFF
--- a/sample-templates/accelerator_single_endpointgroup.json
+++ b/sample-templates/accelerator_single_endpointgroup.json
@@ -15,7 +15,6 @@
         "ap-south-1",
         "ap-northeast-1",
         "ap-northeast-2",
-        "ap-northeast-3",
         "ap-southeast-1",
         "ap-southeast-2",
         "ap-northeast-1",

--- a/sample-templates/accelerator_single_endpointgroup.yaml
+++ b/sample-templates/accelerator_single_endpointgroup.yaml
@@ -19,7 +19,6 @@ Parameters:
     - ap-south-1
     - ap-northeast-1
     - ap-northeast-2
-    - ap-northeast-3
     - ap-southeast-1
     - ap-southeast-2
     - ap-northeast-1


### PR DESCRIPTION
Added a YSON and sample YAML template.  The are equivalent templates, just in two different cloud formation supported formats.  The templates take as an argument the region and endpointid of what the user would like to accelerate as part of their test.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
