### PR TITLE
made arn references write-only

### DIFF
--- a/aws-globalaccelerator-endpointgroup/aws-globalaccelerator-endpointgroup.json
+++ b/aws-globalaccelerator-endpointgroup/aws-globalaccelerator-endpointgroup.json
@@ -95,7 +95,8 @@
     "EndpointGroupRegion"
   ],
   "createOnlyProperties": [
-    "/properties/EndpointGroupRegion"
+    "/properties/EndpointGroupRegion",
+    "/properties/ListenerArn"
   ],
   "readOnlyProperties": [
     "/properties/EndpointGroupArn"

--- a/aws-globalaccelerator-listener/aws-globalaccelerator-listener.json
+++ b/aws-globalaccelerator-listener/aws-globalaccelerator-listener.json
@@ -65,6 +65,9 @@
     "PortRanges",
     "Protocol"
   ],
+  "createOnlyProperties": [
+    "/properties/AcceleratorArn"
+  ],
   "readOnlyProperties": [
     "/properties/ListenerArn"
   ],


### PR DESCRIPTION
The ARN reference to the accelerator in the listener resource is now defined as write only
The ARN reference to the listener in the endpoint group is now defined as write only


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
