### PR TITLE
Added fix for NPE (Null Pointer Exception) and logging in delete handler

### DIFF
--- a/aws-globalaccelerator-endpointgroup/src/main/kotlin/software/amazon/globalaccelerator/endpointgroup/DeleteHandler.kt
+++ b/aws-globalaccelerator-endpointgroup/src/main/kotlin/software/amazon/globalaccelerator/endpointgroup/DeleteHandler.kt
@@ -25,7 +25,7 @@ class DeleteHandler : BaseHandler<CallbackContext>() {
                     ?: return ProgressEvent.defaultSuccessHandler(model)
             deleteEndpointGroup(model, proxy, agaClient)
         } else {
-            HandlerCommons.waitForSynchronizedStep(inferredCallbackContext, model, proxy, agaClient, logger)
+            HandlerCommons.waitForSynchronizedStep(inferredCallbackContext, model, proxy, agaClient, logger, isDelete = true)
         }
     }
 

--- a/aws-globalaccelerator-endpointgroup/src/main/kotlin/software/amazon/globalaccelerator/endpointgroup/HandlerCommons.kt
+++ b/aws-globalaccelerator-endpointgroup/src/main/kotlin/software/amazon/globalaccelerator/endpointgroup/HandlerCommons.kt
@@ -81,8 +81,8 @@ object HandlerCommons {
         return try {
             val request = DescribeEndpointGroupRequest().withEndpointGroupArn(arn)
             proxy.injectCredentialsAndInvoke(request, agaClient::describeEndpointGroup).endpointGroup
-        } catch (eex: EndpointGroupNotFoundException) {
-            logger.error("Did not find endpoint group with arn [$arn]")
+        } catch (ex: EndpointGroupNotFoundException) { // Should we be throwing this instead?
+            logger.debug("Did not find endpoint group with arn [$arn]")
             null
         }
     }

--- a/aws-globalaccelerator-listener/src/main/kotlin/software/amazon/globalaccelerator/listener/DeleteHandler.kt
+++ b/aws-globalaccelerator-listener/src/main/kotlin/software/amazon/globalaccelerator/listener/DeleteHandler.kt
@@ -22,10 +22,9 @@ class DeleteHandler : BaseHandler<CallbackContext>() {
                 ?: CallbackContext(stabilizationRetriesRemaining = HandlerCommons.NUMBER_OF_STATE_POLL_RETRIES, pendingStabilization = false);
         val model = request.desiredResourceState
 
-        HandlerCommons.getListener(model.listenerArn, proxy, agaClient, logger)
-                ?: return ProgressEvent.defaultSuccessHandler(model)
-
         return if (!inferredCallbackContext.pendingStabilization) {
+            HandlerCommons.getListener(model.listenerArn, proxy, agaClient, logger)
+                    ?: return ProgressEvent.defaultSuccessHandler(model)
             deleteListener(model, proxy, agaClient)
         } else {
             HandlerCommons.waitForSynchronizedStep(inferredCallbackContext, model, proxy, agaClient, logger)

--- a/aws-globalaccelerator-listener/src/main/kotlin/software/amazon/globalaccelerator/listener/DeleteHandler.kt
+++ b/aws-globalaccelerator-listener/src/main/kotlin/software/amazon/globalaccelerator/listener/DeleteHandler.kt
@@ -27,7 +27,7 @@ class DeleteHandler : BaseHandler<CallbackContext>() {
                     ?: return ProgressEvent.defaultSuccessHandler(model)
             deleteListener(model, proxy, agaClient)
         } else {
-            HandlerCommons.waitForSynchronizedStep(inferredCallbackContext, model, proxy, agaClient, logger)
+            HandlerCommons.waitForSynchronizedStep(inferredCallbackContext, model, proxy, agaClient, logger, isDelete = true)
         }
     }
 

--- a/aws-globalaccelerator-listener/src/main/kotlin/software/amazon/globalaccelerator/listener/HandlerCommons.kt
+++ b/aws-globalaccelerator-listener/src/main/kotlin/software/amazon/globalaccelerator/listener/HandlerCommons.kt
@@ -27,7 +27,7 @@ object HandlerCommons {
                                 model: ResourceModel,
                                 proxy: AmazonWebServicesClientProxy,
                                 agaClient: AWSGlobalAccelerator,
-                                logger: Logger): ProgressEvent<ResourceModel, CallbackContext> {
+                                logger: Logger): ProgressEvent<ResourceModel, CallbackContext?> {
 
         logger.debug("Waiting for accelerator to be deployed. arn: ${model.acceleratorArn}. " +
                 "Stabilization retries remaining ${context.stabilizationRetriesRemaining}")
@@ -72,7 +72,7 @@ object HandlerCommons {
             val request = DescribeListenerRequest().withListenerArn(arn)
             proxy.injectCredentialsAndInvoke(request, agaClient::describeListener).listener
         } catch (ex: ListenerNotFoundException) {
-            logger.error("Listener not found. arn: [$arn]")
+            logger.debug("Listener not found. arn: [$arn]")
             null
         }
     }

--- a/aws-globalaccelerator-listener/src/main/kotlin/software/amazon/globalaccelerator/listener/UpdateHandler.kt
+++ b/aws-globalaccelerator-listener/src/main/kotlin/software/amazon/globalaccelerator/listener/UpdateHandler.kt
@@ -18,7 +18,7 @@ class UpdateHandler : BaseHandler<CallbackContext>() {
             proxy: AmazonWebServicesClientProxy,
             request: ResourceHandlerRequest<ResourceModel>,
             callbackContext: CallbackContext?,
-            logger: Logger): ProgressEvent<ResourceModel, CallbackContext> {
+            logger: Logger): ProgressEvent<ResourceModel, CallbackContext?> {
         logger.debug("Update Listener Request $request")
         val agaClient = AcceleratorClientBuilder.client
         val inferredCallbackContext = callbackContext
@@ -35,7 +35,7 @@ class UpdateHandler : BaseHandler<CallbackContext>() {
                                    handlerRequest: ResourceHandlerRequest<ResourceModel>,
                                    proxy: AmazonWebServicesClientProxy,
                                    agaClient: AWSGlobalAccelerator,
-                                   logger: Logger): ProgressEvent<ResourceModel, CallbackContext> {
+                                   logger: Logger): ProgressEvent<ResourceModel, CallbackContext?> {
         val listener = updateListener(model, handlerRequest, proxy, agaClient)
         model.clientAffinity = listener.clientAffinity
         model.protocol = listener.protocol


### PR DESCRIPTION
### Overview
I have added fix for NPE (Null Pointer Exception) and logging in delete handler. 

### Reason
- Delete handler for a non-existing endpoint group throws NPE for a get operation on non-existing accelerator. 
- After resource is successfully deleted, delete handler logs "resource not found" as error message in CloudWatch.

### Testing
- I have added coverage for testing both of these fixes.

### Comments
This fix should gracefully handle deletion of an existing resource. One catch is that if customer deletes a non-existing resource, this change logs and succeeds. We can discuss if a better approach would be to fail/throw exception in non-existing case.
