### PR TITLE
Using RPDK v2.0 for Global Accelerator resources

### DIFF
--- a/aws-globalaccelerator-accelerator/.rpdk-config
+++ b/aws-globalaccelerator-accelerator/.rpdk-config
@@ -10,6 +10,7 @@
             "amazon",
             "globalaccelerator",
             "accelerator"
-        ]
+        ],
+        "protocolVersion": "2.0.0"
     }
 }

--- a/aws-globalaccelerator-accelerator/pom.xml
+++ b/aws-globalaccelerator-accelerator/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>1.0.2</version>
+            <version>2.0.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-core -->
         <dependency>

--- a/aws-globalaccelerator-endpointgroup/.rpdk-config
+++ b/aws-globalaccelerator-endpointgroup/.rpdk-config
@@ -10,6 +10,7 @@
             "amazon",
             "globalaccelerator",
             "endpointgroup"
-        ]
+        ],
+        "protocolVersion": "2.0.0"
     }
 }

--- a/aws-globalaccelerator-endpointgroup/pom.xml
+++ b/aws-globalaccelerator-endpointgroup/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>1.0.2</version>
+            <version>2.0.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-core -->
         <dependency>

--- a/aws-globalaccelerator-listener/.rpdk-config
+++ b/aws-globalaccelerator-listener/.rpdk-config
@@ -10,6 +10,7 @@
             "amazon",
             "globalaccelerator",
             "listener"
-        ]
+        ],
+        "protocolVersion": "2.0.0"
     }
 }

--- a/aws-globalaccelerator-listener/pom.xml
+++ b/aws-globalaccelerator-listener/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>1.0.2</version>
+            <version>2.0.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-core -->
         <dependency>


### PR DESCRIPTION
RPDK v2.0 improves resource stability, with improved retry strategy and fail-fast instead of waiting for 2 hours.