### PR TITLE
Adding input files for all three cloud formation resources

### DIFF
--- a/aws-globalaccelerator-accelerator/README.md
+++ b/aws-globalaccelerator-accelerator/README.md
@@ -1,16 +1,20 @@
 # AWS::GlobalAccelerator::Accelerator
 
-Building and testing the project
+#### Building and testing the project
 There are a couple options for building and testing the project.
 
 1. "mvn clean package" - this will build clean and build the project.
 2. "cfn submit -v --region <desired_region> - This will deploy the resource as a private resource to your aws account.  This may take a couple minutes.
 3. "cfn cloudformation set-type-default-version --type "RESOURCE" --type-name AWS::GlobalAccelerator::Accelerator --version-id "xxxxxxxxx" - This will set the version that is used when submitted new cloud formation templates against the given resource type.  you can list versions using the aws cloudformation list-type-versions command.
 
-Files:
-1. aws-globalaccelerator-accelerator.json - This file contains the schema definition for the accelerator resource.  It also drives auto generated classes from rpdk.
+##### Files:
 
-# How to test locally
+1. aws-globalaccelerator-accelerator.json - This file contains the schema definition for the accelerator resource.  It also drives auto generated classes from rpdk.
+2. `inputs/inputs_1_create.json` - This file is used during the contract tests which are run when using the "cfn submit" or "cfn test" commands.
+3. `inputs/inputs_1_invalid.json` - This file is used during the contract tests which are run when using the "cfn submit" or "cfn test" commands.
+4. `inputs/inputs_1_update.json` - This file is used during the contract tests which are run when using the "cfn submit" or "cfn test" commands.
+
+#### How to test locally
 2 ways of testing:
 1. Sam local invoke
 2. Deploy stack in your local (cfn submit and aws cfn create-stack)

--- a/aws-globalaccelerator-accelerator/inputs/inputs_1_create.json
+++ b/aws-globalaccelerator-accelerator/inputs/inputs_1_create.json
@@ -1,0 +1,5 @@
+{
+  "Name": "ContractTestAccelerator",
+  "Enabled": true,
+  "IpAddressType": "IPV4"
+}

--- a/aws-globalaccelerator-accelerator/inputs/inputs_1_invalid.json
+++ b/aws-globalaccelerator-accelerator/inputs/inputs_1_invalid.json
@@ -1,0 +1,5 @@
+{
+  "Name": "@Invalid.Accelerator",
+  "Enabled": true,
+  "IpAddressType": "IPV4"
+}

--- a/aws-globalaccelerator-accelerator/inputs/inputs_1_update.json
+++ b/aws-globalaccelerator-accelerator/inputs/inputs_1_update.json
@@ -1,0 +1,5 @@
+{
+  "Name": "UpdatedTestAccelerator",
+  "Enabled": false,
+  "IpAddressType": "IPV4"
+}

--- a/aws-globalaccelerator-endpointgroup/README.md
+++ b/aws-globalaccelerator-endpointgroup/README.md
@@ -10,6 +10,9 @@ There are a couple options for building and testing the project.
 ##### Files:
 
 1. `aws-globalaccelerator-endpointgroup.json` - This file contains the schema definition for the endpoint group resource.  It also drives auto generated classes from rpdk.
+2. `inputs/inputs_1_create.json` - This file is used during the contract tests which are run when using the "cfn submit" or "cfn test" commands.  When running either of those commands, replace {{ListenerArn}} in this file with a valid Listener Arn from one of your Global Accelerators in your aws account.
+3. `inputs/inputs_1_invalid.json` - This file is used during the contract tests which are run when using the "cfn submit" or "cfn test" commands.
+4. `inputs/inputs_1_update.json` - This file is used during the contract tests which are run when using the "cfn submit" or "cfn test" commands.  When running either of those commands, replace {{ListenerArn}} in this file with a valid Listener Arn from one of your Global Accelerators in your aws account.
 
 
 #### How to test locally

--- a/aws-globalaccelerator-endpointgroup/inputs/inputs_1_create.json
+++ b/aws-globalaccelerator-endpointgroup/inputs/inputs_1_create.json
@@ -1,0 +1,4 @@
+{
+  "ListenerArn": "{{ListenerArn}}",
+  "EndpointGroupRegion": "us-west-2"
+}

--- a/aws-globalaccelerator-endpointgroup/inputs/inputs_1_invalid.json
+++ b/aws-globalaccelerator-endpointgroup/inputs/inputs_1_invalid.json
@@ -1,0 +1,3 @@
+{
+  "TrafficDialPercentage": -1
+}

--- a/aws-globalaccelerator-endpointgroup/inputs/inputs_1_update.json
+++ b/aws-globalaccelerator-endpointgroup/inputs/inputs_1_update.json
@@ -1,0 +1,5 @@
+{
+  "ListenerArn": "{{ListenerArn}}",
+  "EndpointGroupRegion": "us-west-2",
+  "TrafficDialPercentage": 42
+}

--- a/aws-globalaccelerator-listener/README.md
+++ b/aws-globalaccelerator-listener/README.md
@@ -10,6 +10,9 @@ There are a couple options for building and testing the project.
 ##### Files:
 
 1. `aws-globalaccelerator-listener.json` - This file contains the schema definition for the listener resource.  It also drives auto generated classes from rpdk.
+2. `inputs/inputs_1_create.json` - This file is used during the contract tests which are run when using the "cfn submit" or "cfn test" commands.  When running either of those commands, replace {{AcceleratorArn}} in this file with a valid Global Accelerator Arn from your aws account.
+3. `inputs/inputs_1_invalid.json` - This file is used during the contract tests which are run when using the "cfn submit" or "cfn test" commands.
+4. `inputs/inputs_1_update.json` - This file is used during the contract tests which are run when using the "cfn submit" or "cfn test" commands.  When running either of those commands, replace {{AcceleratorArn}} in this file with a valid Global Accelerator Arn from your aws account.
 
 
 #### How to test locally

--- a/aws-globalaccelerator-listener/inputs/inputs_1_create.json
+++ b/aws-globalaccelerator-listener/inputs/inputs_1_create.json
@@ -1,0 +1,10 @@
+{
+  "AcceleratorArn": "{{AcceleratorArn}}",
+  "PortRanges": [
+    {
+      "FromPort": 4242,
+      "ToPort": 4242
+    }
+  ],
+  "Protocol": "TCP"
+}

--- a/aws-globalaccelerator-listener/inputs/inputs_1_invalid.json
+++ b/aws-globalaccelerator-listener/inputs/inputs_1_invalid.json
@@ -1,0 +1,8 @@
+{
+  "PortRanges": [
+    {
+      "FromPort": -1,
+      "ToPort": 81
+    }
+  ]
+}

--- a/aws-globalaccelerator-listener/inputs/inputs_1_update.json
+++ b/aws-globalaccelerator-listener/inputs/inputs_1_update.json
@@ -1,0 +1,10 @@
+{
+  "AcceleratorArn": "{{AcceleratorArn}}",
+  "PortRanges": [
+    {
+      "FromPort": 4242,
+      "ToPort": 4243
+    }
+  ],
+  "Protocol": "TCP"
+}


### PR DESCRIPTION
*Description of changes:*
Adding the three input files per cloud formation resource in order for the contract tests to be able to run during registration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
