### PR TITLE
Adding DualStack and IPv6Addresses to Accelerator

### DIFF
--- a/aws-globalaccelerator-accelerator/aws-globalaccelerator-accelerator.json
+++ b/aws-globalaccelerator-accelerator/aws-globalaccelerator-accelerator.json
@@ -28,7 +28,7 @@
     },
     "IpAddress": {
       "pattern": "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$",
-      "description": "The IP addresses from BYOIP Prefix pool.",
+      "description": "An IPV4 address",
       "type": "string"
     }
   },
@@ -46,7 +46,7 @@
       "default": "IPV4",
       "enum": [
         "IPV4",
-        "IPV6"
+        "DUAL_STACK"
       ]
     },
     "IpAddresses": {
@@ -72,6 +72,18 @@
       "items": {
         "type": "string"
       }
+    },
+    "Ipv6Addresses": {
+      "description": "The IPv6 addresses assigned if the accelerator is dualstack",
+      "default": null,
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "DualStackDnsName": {
+      "description": "The Domain Name System (DNS) name that Global Accelerator creates that points to your accelerator's static IPv6 addresses.",
+      "type": "string"
     },
     "AcceleratorArn": {
       "description": "The Amazon Resource Name (ARN) of the accelerator.",
@@ -122,7 +134,9 @@
   "readOnlyProperties": [
     "/properties/AcceleratorArn",
     "/properties/DnsName",
-    "/properties/Ipv4Addresses"
+    "/properties/Ipv4Addresses",
+    "/properties/Ipv6Addresses",
+    "/properties/DualStackDnsName"
   ],
   "primaryIdentifier": [
     "/properties/AcceleratorArn"

--- a/aws-globalaccelerator-accelerator/aws-globalaccelerator-accelerator.json
+++ b/aws-globalaccelerator-accelerator/aws-globalaccelerator-accelerator.json
@@ -63,7 +63,7 @@
       "type": "boolean"
     },
     "DnsName": {
-      "description": "The Domain Name System (DNS) name that Global Accelerator creates that points to your accelerator's static IP addresses.",
+      "description": "The Domain Name System (DNS) name that Global Accelerator creates that points to your accelerator's static IPv4 addresses.",
       "type": "string"
     },
     "Ipv4Addresses": {
@@ -82,7 +82,7 @@
       }
     },
     "DualStackDnsName": {
-      "description": "The Domain Name System (DNS) name that Global Accelerator creates that points to your accelerator's static IPv6 addresses.",
+      "description": "The Domain Name System (DNS) name that Global Accelerator creates that points to your accelerator's static IPv4 and IPv6 addresses.",
       "type": "string"
     },
     "AcceleratorArn": {

--- a/aws-globalaccelerator-accelerator/pom.xml
+++ b/aws-globalaccelerator-accelerator/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-globalaccelerator</artifactId>
-            <version>1.12.62</version>
+            <version>1.12.272</version>
         </dependency>
     </dependencies>
 

--- a/aws-globalaccelerator-accelerator/resource-role.yaml
+++ b/aws-globalaccelerator-accelerator/resource-role.yaml
@@ -15,6 +15,13 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/AWS-GlobalAccelerator-Accelerator/*
       Path: "/"
       Policies:
         - PolicyName: ResourceTypePolicy

--- a/aws-globalaccelerator-accelerator/resource-role.yaml
+++ b/aws-globalaccelerator-accelerator/resource-role.yaml
@@ -15,13 +15,6 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
-            Condition:
-              StringEquals:
-                aws:SourceAccount:
-                  Ref: AWS::AccountId
-              StringLike:
-                aws:SourceArn:
-                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/AWS-GlobalAccelerator-Accelerator/*
       Path: "/"
       Policies:
         - PolicyName: ResourceTypePolicy

--- a/aws-globalaccelerator-accelerator/src/main/kotlin/software/amazon/globalaccelerator/accelerator/CreateHandler.kt
+++ b/aws-globalaccelerator-accelerator/src/main/kotlin/software/amazon/globalaccelerator/accelerator/CreateHandler.kt
@@ -41,6 +41,7 @@ class CreateHandler : BaseHandler<CallbackContext?>() {
         model.apply {
             this.acceleratorArn = acc.acceleratorArn
             this.dnsName = acc.dnsName
+            this.dualStackDnsName = acc.dualStackDnsName
             this.ipAddresses = acc.ipSets?.flatMap { it.ipAddresses }
         }
         val callbackContext: CallbackContext? = CallbackContext(HandlerCommons.NUMBER_OF_STATE_POLL_RETRIES)

--- a/aws-globalaccelerator-accelerator/src/main/kotlin/software/amazon/globalaccelerator/accelerator/HandlerCommons.kt
+++ b/aws-globalaccelerator-accelerator/src/main/kotlin/software/amazon/globalaccelerator/accelerator/HandlerCommons.kt
@@ -80,9 +80,11 @@ object HandlerCommons {
             this.enabled = accelerator.enabled
             this.ipAddressType = accelerator.ipAddressType
             this.dnsName = accelerator.dnsName
-            this.ipAddresses = accelerator.ipSets?.flatMap { it.ipAddresses }
+            this.dualStackDnsName = accelerator.dualStackDnsName
+            this.ipAddresses = accelerator.ipSets?.filter { it.ipFamily.equals("IPV4", ignoreCase = true) }?.flatMap { it.ipAddresses }
             this.tags = tags.map { Tag(it.key, it.value) }
             this.ipv4Addresses = accelerator.ipSets?.filter { it.ipFamily.equals("IPV4", ignoreCase = true) }?.flatMap { it.ipAddresses }
+            this.ipv6Addresses = accelerator.ipSets?.filter { it.ipFamily.equals("IPV6", ignoreCase = true) }?.flatMap { it.ipAddresses }
         }
     }
 }

--- a/aws-globalaccelerator-accelerator/src/test/kotlin/software/amazon/globalaccelerator/accelerator/ListHanderTest.kt
+++ b/aws-globalaccelerator-accelerator/src/test/kotlin/software/amazon/globalaccelerator/accelerator/ListHanderTest.kt
@@ -37,14 +37,23 @@ class ListHandlerTest {
     private val ipFamily = "IPV4"
     private val acceleratorArn1 = "arn:aws:globalaccelerator::444607872184:accelerator/88127aa5-01d8-484c-80a0-349daaefce1d"
     private val ipAddresses1 = listOf("10.10.10.1", "10.10.10.2")
-    private val ipSet1 = IpSet().withIpAddresses(ipAddresses1)
+    private val ipSet1 = IpSet().withIpAddresses(ipAddresses1).withIpFamily("IPV4")
     private val name1 = "Name1"
     private val dnsName1 = "DNS_NAME_HERE"
     private val acceleratorArn2 = "arn:aws:globalaccelerator::444607872184:accelerator/86753aa5-01d8-484c-80a0-349daaefce09"
     private val ipAddresses2 = listOf("10.10.42.1", "10.10.42.2")
-    private val ipSet2 = IpSet().withIpAddresses(ipAddresses2)
+    private val ipSet2 = IpSet().withIpAddresses(ipAddresses2).withIpFamily("IPV4")
     private val name2 = "Name2"
     private val dnsName2 = "DNS_NAME_HERE_TWO"
+    private val dualStackAddressType = "DUAL_STACK"
+    private val acceleratorArn3 = "arn:aws:globalaccelerator::444607872184:accelerator/86753aa5-01d8-484c-80a0-349daaef4242"
+    private val ipAddresses3 = listOf("10.10.84.1", "10.10.84.2")
+    private val ipSet3 = IpSet().withIpAddresses(ipAddresses3).withIpFamily("IPV4")
+    private val ipv6Addresses = listOf("2600:9000:a16f:94b4:4352:4d16:11d5:561b", "2600:9000:a1f9:b20f:f92:8279:1e86:ae75")
+    private val ipSet4 = IpSet().withIpAddresses(ipv6Addresses).withIpFamily("IPV6")
+    private val name3 = "Name2"
+    private val dnsName3 = "DNS_NAME_HERE_TWO"
+    private val dualStackDnsName = "DUAL_STACK_DNS_NAME_HERE"
 
     private fun createTestResourceModel(arn: String, ipAddresses: List<String>, name: String, dnsName: String): ResourceModel {
         return ResourceModel.builder()
@@ -61,6 +70,11 @@ class ListHandlerTest {
     fun handleRequest_returnsMappedAccelerators() {
         val model1 = createTestResourceModel(acceleratorArn1, ipAddresses1, name1, dnsName1)
         val model2 = createTestResourceModel(acceleratorArn2, ipAddresses2, name2, dnsName2)
+        val model3 = createTestResourceModel(acceleratorArn3, ipAddresses3, name3, dnsName3)
+        model3.dualStackDnsName = dualStackDnsName
+        model3.ipv6Addresses = ipv6Addresses
+        model3.ipAddressType = dualStackAddressType
+
         val accelerators = mutableListOf(
                 Accelerator()
                         .withAcceleratorArn(acceleratorArn1)
@@ -77,7 +91,16 @@ class ListHandlerTest {
                         .withIpAddressType(ipFamily)
                         .withName(name2)
                         .withDnsName(dnsName2)
-                        .withIpSets(ipSet2)
+                        .withIpSets(ipSet2),
+                Accelerator()
+                        .withAcceleratorArn(acceleratorArn3)
+                        .withStatus(AcceleratorStatus.IN_PROGRESS.toString())
+                        .withEnabled(true)
+                        .withIpAddressType(dualStackAddressType)
+                        .withName(name3)
+                        .withDnsName(dnsName3)
+                        .withDualStackDnsName(dualStackDnsName)
+                        .withIpSets(arrayListOf(ipSet3, ipSet4))
         )
 
         val listAcceleratorsResult = ListAcceleratorsResult()
@@ -94,20 +117,38 @@ class ListHandlerTest {
         assertNull(response.message)
         assertNotNull(response.resourceModels)
         assertNull(response.nextToken)
-        assertEquals(2, response.resourceModels.size)
+        assertEquals(3, response.resourceModels.size)
+
         assertEquals(acceleratorArn1, response.resourceModels[0].acceleratorArn)
         assertEquals(model1.ipAddressType, response.resourceModels[0].ipAddressType)
         assertEquals(model1.name, response.resourceModels[0].name)
         assertEquals(model1.dnsName, response.resourceModels[0].dnsName)
+        assertNull(response.resourceModels[0].dualStackDnsName)
         assertTrue(response.resourceModels[0].enabled)
         assertEquals(model1.ipAddresses, response.resourceModels[0].ipAddresses)
+        assertEquals(model1.ipAddresses, response.resourceModels[0].ipv4Addresses)
+        assertEquals(arrayListOf<String>(), response.resourceModels[0].ipv6Addresses)
+
         assertEquals(acceleratorArn2, response.resourceModels[1].acceleratorArn)
         assertEquals(model2.ipAddressType, response.resourceModels[1].ipAddressType)
         assertEquals(model2.name, response.resourceModels[1].name)
         assertEquals(model2.dnsName, response.resourceModels[1].dnsName)
+        assertNull(response.resourceModels[1].dualStackDnsName)
         assertTrue(response.resourceModels[1].enabled)
         assertEquals(model2.ipAddresses, response.resourceModels[1].ipAddresses)
-    }
+        assertEquals(model2.ipAddresses, response.resourceModels[1].ipv4Addresses)
+        assertEquals(arrayListOf<String>(), response.resourceModels[1].ipv6Addresses)
+ 
+        assertEquals(acceleratorArn3, response.resourceModels[2].acceleratorArn)
+        assertEquals(model3.ipAddressType, response.resourceModels[2].ipAddressType)
+        assertEquals(model3.name, response.resourceModels[2].name)
+        assertEquals(model3.dnsName, response.resourceModels[2].dnsName)
+        assertEquals(model3.dualStackDnsName, response.resourceModels[2].dualStackDnsName)
+        assertTrue(response.resourceModels[2].enabled)
+        assertEquals(model3.ipAddresses, response.resourceModels[2].ipAddresses)
+        assertEquals(model3.ipAddresses, response.resourceModels[2].ipv4Addresses)
+        assertEquals(model3.ipv6Addresses, response.resourceModels[2].ipv6Addresses)
+   }
 
     @Test
     fun handleRequest_noAccelerators() {

--- a/aws-globalaccelerator-accelerator/src/test/kotlin/software/amazon/globalaccelerator/accelerator/ListHanderTest.kt
+++ b/aws-globalaccelerator-accelerator/src/test/kotlin/software/amazon/globalaccelerator/accelerator/ListHanderTest.kt
@@ -138,7 +138,7 @@ class ListHandlerTest {
         assertEquals(model2.ipAddresses, response.resourceModels[1].ipAddresses)
         assertEquals(model2.ipAddresses, response.resourceModels[1].ipv4Addresses)
         assertEquals(arrayListOf<String>(), response.resourceModels[1].ipv6Addresses)
- 
+
         assertEquals(acceleratorArn3, response.resourceModels[2].acceleratorArn)
         assertEquals(model3.ipAddressType, response.resourceModels[2].ipAddressType)
         assertEquals(model3.name, response.resourceModels[2].name)

--- a/aws-globalaccelerator-accelerator/template.yml
+++ b/aws-globalaccelerator-accelerator/template.yml
@@ -5,6 +5,7 @@ Description: AWS SAM template for the AWS::GlobalAccelerator::Accelerator resour
 Globals:
   Function:
     Timeout: 60  # docker start-up times can be long for SAM CLI
+    MemorySize: 256
 
 Resources:
   TypeFunction:


### PR DESCRIPTION
*Description of changes:*
Adding DualStack to the IpAddressType enum to allow for creation of Dual Stack Accelerators
Adding DualStack DNS Name Property
Adding Ipv6Addresses Property

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
