### PR TITLE
Fixing issue with updating EndpointConfiguration ClientIPPreservation…

### DIFF
--- a/aws-globalaccelerator-endpointgroup/src/main/kotlin/software/amazon/globalaccelerator/endpointgroup/UpdateHandler.kt
+++ b/aws-globalaccelerator-endpointgroup/src/main/kotlin/software/amazon/globalaccelerator/endpointgroup/UpdateHandler.kt
@@ -39,7 +39,7 @@ class UpdateHandler : BaseHandler<CallbackContext>() {
                                     agaClient: AWSGlobalAccelerator): ProgressEvent<ResourceModel, CallbackContext?> {
         val convertedEndpointConfigurations = model.endpointConfigurations?.map {
             EndpointConfiguration()
-                    .withEndpointId(it.endpointId).withWeight(it.weight)
+                    .withEndpointId(it.endpointId).withWeight(it.weight).withClientIPPreservationEnabled(it.clientIPPreservationEnabled)
         }
         val trafficDialPercentage = model.trafficDialPercentage?.toFloat() ?: 100.0f
         val request = UpdateEndpointGroupRequest()

--- a/aws-globalaccelerator-endpointgroup/src/test/kotlin/software/amazon/globalaccelerator/endpointgroup/UpdateHandlerTest.kt
+++ b/aws-globalaccelerator-endpointgroup/src/test/kotlin/software/amazon/globalaccelerator/endpointgroup/UpdateHandlerTest.kt
@@ -52,8 +52,8 @@ class UpdateHandlerTest {
 
     private fun createTestResourceModel(): ResourceModel {
         val endpointConfigurations = ArrayList<EndpointConfiguration>()
-        endpointConfigurations.add(EndpointConfiguration.builder().endpointId("EPID1").build())
-        endpointConfigurations.add(EndpointConfiguration.builder().endpointId("EPID2").build())
+        endpointConfigurations.add(EndpointConfiguration.builder().endpointId("EPID1").weight(100).clientIPPreservationEnabled(true).build())
+        endpointConfigurations.add(EndpointConfiguration.builder().endpointId("EPID2").weight(100).clientIPPreservationEnabled(true).build())
 
         return ResourceModel.builder()
                 .endpointGroupArn(endpointGroupArn)
@@ -298,4 +298,41 @@ class UpdateHandlerTest {
         verify(exactly = 1) { proxy.injectCredentialsAndInvoke(ofType(), ofType<ProxyUpdateEndpointGroup>()) }
         assertEquals(ArrayList<String>(), updateEndpointGroupRequestSlot.captured.portOverrides) // Empty array to clean port-overrides.
     }
+
+    @Test
+    fun handleRequest_UpdateEndpointGroupWithUpdatedEndpointConfigurations() {
+        val previousModel = createTestResourceModel()
+        val desiredModel = createTestResourceModel()
+        val endpointConfigurations = ArrayList<EndpointConfiguration>()
+        endpointConfigurations.add(EndpointConfiguration.builder().endpointId("EPID1").weight(50).clientIPPreservationEnabled(false).build())
+        endpointConfigurations.add(EndpointConfiguration.builder().endpointId("EPID2").weight(50).clientIPPreservationEnabled(false).build())
+        endpointConfigurations.add(EndpointConfiguration.builder().endpointId("EPID3").weight(50).clientIPPreservationEnabled(true).build())
+        desiredModel.endpointConfigurations = endpointConfigurations
+
+        val describeEndpointGroupResult = DescribeEndpointGroupResult()
+                .withEndpointGroup(EndpointGroup()
+                        .withEndpointGroupArn(endpointGroupArn))
+        every { proxy.injectCredentialsAndInvoke(ofType(), ofType<ProxyDescribeEndpointGroup>()) } returns describeEndpointGroupResult
+
+        val updateEndpointGroupResult = UpdateEndpointGroupResult()
+                .withEndpointGroup(EndpointGroup().withEndpointGroupArn(endpointGroupArn))
+        every { proxy.injectCredentialsAndInvoke(ofType(), ofType<ProxyUpdateEndpointGroup>()) } returns updateEndpointGroupResult
+
+        val request = ResourceHandlerRequest.builder<ResourceModel>()
+                .desiredResourceState(desiredModel)
+                .previousResourceState(previousModel)
+                .build()
+
+        val response = UpdateHandler().handleRequest(proxy, request, null, logger)
+
+        assertNotNull(response)
+        assertEquals(OperationStatus.IN_PROGRESS, response.status)
+        assertNotNull(response.resourceModel)
+        assertNotNull(response.callbackContext)
+        assertEquals(0, response.callbackDelaySeconds)
+        assertEquals(endpointGroupArn, response.resourceModel.endpointGroupArn)
+        assertTrue(response.callbackContext!!.pendingStabilization)
+        assertEquals(3, response.resourceModel.endpointConfigurations.size)
+        assertEquals(response.resourceModel.endpointConfigurations, endpointConfigurations)
+    }    
 }

--- a/aws-globalaccelerator-endpointgroup/src/test/kotlin/software/amazon/globalaccelerator/endpointgroup/UpdateHandlerTest.kt
+++ b/aws-globalaccelerator-endpointgroup/src/test/kotlin/software/amazon/globalaccelerator/endpointgroup/UpdateHandlerTest.kt
@@ -334,5 +334,5 @@ class UpdateHandlerTest {
         assertTrue(response.callbackContext!!.pendingStabilization)
         assertEquals(3, response.resourceModel.endpointConfigurations.size)
         assertEquals(response.resourceModel.endpointConfigurations, endpointConfigurations)
-    }    
+    }
 }


### PR DESCRIPTION
…Enabled

*Issue #, if available:*
 https://t.corp.amazon.com/P105678591

*Description of changes:*
Updated the UpdateHandler to update ClientIPPreservationEnabled correctly.  Also added unit test for new fix.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
